### PR TITLE
Added instructions to run slides locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@ Training materials for **Microservices on Cloud Foundry: Going Cloud Native**
 This course is designed to give its students a hands on experience of designing
 applications for Cloud Foundry. We will give an overview of Cloud Foundry and
 its tools from the point of view of an application developer and how to
-architect polyglot applications for deployment and scaling in the cloud. 
+architect polyglot applications for deployment and scaling in the cloud.
 
 This training is targeted at developers with little hands-on Cloud Foundry
 experience and those who have an interest in deploying innovative,
-microservice-based systems into the cloud. 
+microservice-based systems into the cloud.
 
 ## System Requirements
 
@@ -26,3 +26,12 @@ microservice-based systems into the cloud.
 * `o`: Toggle overview
 * `.` (`Period` or `b`: Turn screen black)
 * `Esc`: Escape from full-screen, or toggle overview
+
+## Running slides locally
+
+Once [node.js is installed](https://nodejs.org/en/download/), from your
+terminal, install reveal-md globally: `npm install -g reveal-md`
+
+From the training dir - `microservices-training` - run `reveal-md 0-introduction/slides.md`
+to view the slides for the first topic. To view the slides for the second topic,
+run `reveal-md 1-monolith/slides.md`. Same for all other topics.


### PR DESCRIPTION
## What

Added instructions to run slides locally in `README` file. The section is based on a similar one taken from [this Cloud Credo repository](https://github.com/CloudCredo/training-cf-zero-to-hero).
## Why

I've never run reveal.js slides locally and it took me some time to see how to do it after cloning the repository.
